### PR TITLE
trigger coolify deployment after image build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,8 +55,13 @@ jobs:
               body: '`docker pull ${{ env.DOCKER_REPO }}/volunteer-scheduler-${{ matrix.package }}:${{ github.sha }}`'
             })
 
-      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
+  deploy-to-coolify:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [ docker ]
+    runs-on: [ ubuntu-22.04 ]
+    environment: production
+    steps:
+      - run: |
           # trigger deployment for astro
           curl --request GET --header 'Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}' '${{ secrets.COOLIFY_DEPLOY_ASTRO_WEBHOOK }}'
           # trigger deployment for payload

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - if: ${{ github.ref != 'refs/heads/main' }}
+      - if: github.event_name == 'pull_request'
         run: echo "IMAGE_TAGS=${{ env.DOCKER_REPO }}/${{ github.event.repository.name }}-${{ matrix.package }}:${{ github.sha }}" >> "$GITHUB_ENV"
 
-      - if: ${{ github.ref == 'refs/heads/main' }}
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo "IMAGE_TAGS=${{ env.DOCKER_REPO }}/${{ github.event.repository.name }}-${{ matrix.package }}:${{ github.sha }},${{ env.DOCKER_REPO }}/${{ github.event.repository.name }}-${{ matrix.package }}:latest" >> "$GITHUB_ENV"
 
       - uses: docker/login-action@v3
@@ -54,3 +54,10 @@ jobs:
               repo: context.repo.repo,
               body: '`docker pull ${{ env.DOCKER_REPO }}/volunteer-scheduler-${{ matrix.package }}:${{ github.sha }}`'
             })
+
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          # trigger deployment for astro
+          curl --request GET --header 'Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}' '${{ secrets.COOLIFY_DEPLOY_ASTRO_WEBHOOK }}'
+          # trigger deployment for payload
+          curl --request GET --header 'Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}' '${{ secrets.COOLIFY_DEPLOY_PAYLOAD_WEBHOOK }}'


### PR DESCRIPTION
Until we figure out logistics of different app versions and database schema changes, both applications should always be deployed together.