### PR TITLE
add description for link previews

### DIFF
--- a/packages/astro/src/layouts/layout.astro
+++ b/packages/astro/src/layouts/layout.astro
@@ -21,7 +21,7 @@ const color = {
 <html lang="en" class:list={[{ dark: theme === "dark" }]}>
   <head>
     <meta charset="UTF-8" />
-    <meta name="description" content="Astro description" />
+    <meta name="description" content="Discover and sign up for volunteering shifts at De Sering!" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
Closes #68.

Result:
![image](https://github.com/user-attachments/assets/36d0bd3f-80ff-4aac-914a-b2d48991cfbb)
