### PR TITLE
fix: add margin between month and date select

### DIFF
--- a/src/components/event-overview/date-select.tsx
+++ b/src/components/event-overview/date-select.tsx
@@ -80,6 +80,7 @@ const DateButton = ({
           gridRow="1"
           left="0"
           paddingInline="4"
+          marginBlockEnd="4"
           position="sticky"
           zIndex="1"
           maskImage={`linear-gradient(to right, transparent 0px, ${token("colors.bg.canvas")} 16px)`}


### PR DESCRIPTION
Add margins between month and date-select. 

Before:
<img width="348" height="234" alt="Screenshot 2025-12-13 at 5 18 04 PM" src="https://github.com/user-attachments/assets/e3cbbf42-0ed1-4f22-bb91-9401c118f8bd" />

After:
<img width="345" height="233" alt="Screenshot 2025-12-13 at 5 19 42 PM" src="https://github.com/user-attachments/assets/450c5b12-e8a9-433e-935a-955973d41a6f" />
