### PR TITLE
fix: align month in date-select with container left

### DIFF
--- a/src/components/event-overview/date-select.tsx
+++ b/src/components/event-overview/date-select.tsx
@@ -1,6 +1,6 @@
 import { format, startOfDay } from "date-fns";
 import { useEffect, useRef } from "react";
-import { Grid, GridItem } from "styled-system/jsx";
+import { Box, Grid, GridItem, panda } from "styled-system/jsx";
 import { token } from "styled-system/tokens";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
@@ -42,6 +42,48 @@ export const DateSelect = (props: Props) => (
   </Grid>
 );
 
+// compute the inline start offset needed to align the sticky month with a centered max-width container
+// (viewport − minimum(viewport, containerMaxWidth)) / numberOfMarg`inAuto − paddingInline
+const containerInlineStartAlignment = `((100vw - min(100vw, ${token("sizes.8xl")})) / 2)`;
+
+const ContainerAlignedGridItem = panda(GridItem, {
+  base: {
+    "--bg-color": { base: "colors.gray.4", _dark: "colors.gray.2" },
+
+    position: "sticky",
+    overflow: "visible",
+    zIndex: "1",
+    width: "0",
+    gridRow: "1",
+
+    _before: {
+      display: "block",
+      position: "absolute",
+      content: '""',
+      backgroundImage: `linear-gradient(to right, transparent 0px, var(--bg-color) ${token("spacing.4")})`,
+      left: "-8",
+      width: "8",
+      height: "full",
+    },
+
+    // align with container
+    insetInlineStart: `calc(${containerInlineStartAlignment} + var(--inset-inline-start-offset))`,
+    "--inset-inline-start-offset": {
+      base: `spacing.4`,
+      md: `spacing.6`,
+      lg: `spacing.8`,
+    },
+  },
+});
+
+const ContainerAlignedGridItemInner = panda(Box, {
+  base: {
+    background: "var(--bg-color)",
+    whiteSpace: "nowrap",
+    width: "[250px]",
+  },
+});
+
 type DateButtonProps = {
   item: DateItem;
   itemIndex: number;
@@ -60,10 +102,6 @@ const DateButton = ({
   const isFirstItem = itemIndex === 0;
   const showMonthLabel = isFirstOfMonth || isFirstItem;
 
-  // compute the left offset needed to align the sticky month with a centered max-width container
-  // (viewport − minimum(viewport, containerMaxWidth)) / numberOfMarginAuto − paddingInline
-  const monthLabelLeftAlignment = `((100vw - min(100vw, ${token("sizes.8xl")})) / 2) - ${token("spacing.4")}`;
-
   useEffect(() => {
     if (selected && ref.current) {
       ref.current.scrollIntoView({
@@ -77,23 +115,11 @@ const DateButton = ({
   return (
     <>
       {showMonthLabel && (
-        <GridItem
-          background={{ base: "gray.4", _dark: "gray.2" }}
-          colSpan={4}
-          gridRow="1"
-          left={{
-            // add container responsive padding
-            base: `calc(${monthLabelLeftAlignment} + ${token("spacing.4")})`,
-            md: `calc(${monthLabelLeftAlignment} + ${token("spacing.6")})`,
-            lg: `calc(${monthLabelLeftAlignment} + ${token("spacing.8")})`,
-          }}
-          paddingInline="4"
-          position="sticky"
-          zIndex="1"
-          maskImage={`linear-gradient(to right, transparent 0px, ${token("colors.bg.canvas")} 16px)`}
-        >
-          <Text>{format(item.date, "MMMM yyyy")}</Text>
-        </GridItem>
+        <ContainerAlignedGridItem aria-hidden="true">
+          <ContainerAlignedGridItemInner>
+            {format(item.date, "MMMM yyyy")}
+          </ContainerAlignedGridItemInner>
+        </ContainerAlignedGridItem>
       )}
 
       <GridItem gridRow="2">


### PR DESCRIPTION
Resolves #251 

Feel free to let me know of any alternatives.

The mathematical madness is to align the left side with `Container`. Because `position: sticky` has be a direct child of the scrolling container, I am not able to wrap it inside container.
Placing the container inside the grid or spanning the grid is not viable since the month also needs to be aligned with the 1st day.