### PR TITLE
chore: do not automatically request PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @desering/volunteer-scheduler-maintainers


### PR DESCRIPTION
This is so that we can re-add @spaaacetoast to the @desering/volunteer-scheduler-maintainers  group without overflowing them with notifications :)

People naturally use this group to request reviews, and missing a maintainer causes confusion.