### PR TITLE
chore: extend auth token lifetime to 31 days

### DIFF
--- a/src/collections/users/index.ts
+++ b/src/collections/users/index.ts
@@ -19,7 +19,7 @@ export const Users: CollectionConfig = {
   auth: {
     loginWithUsername: false,
     maxLoginAttempts: 0,
-    tokenExpiration: 7 * 24 * 60 * 60, // 7 days in seconds
+    tokenExpiration: 31 * 24 * 60 * 60, // 31 days in seconds
     useSessions: false,
   },
   fields: [


### PR DESCRIPTION
This change addresses the complaint that people get logged out too frequently.

In the medium term, we are going to switch to session auth and implement automated session refresh.