### PR TITLE
feat: Adding skills page for users

### DIFF
--- a/src/app/(scheduler)/account/skills/page.tsx
+++ b/src/app/(scheduler)/account/skills/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Edit, Save } from "lucide-react";
+import Image from "next/image";
+import { useState } from "react";
+import { Container, HStack, panda } from "styled-system/jsx";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Table } from "@/components/ui/table";
+import type { Skill, UsersSkill } from "@/payload-types";
+
+interface SkillWithUserStatus extends Skill {
+  userSkill?: UsersSkill;
+  isLearnt: boolean;
+}
+
+export default function SkillsPage() {
+  const [isEditing, setIsEditing] = useState(false);
+  const [selectedSkills, setSelectedSkills] = useState<Record<number, boolean>>(
+    {},
+  );
+  const queryClient = useQueryClient();
+
+  // Fetch all skills
+  const { data: skills = [], isLoading: skillsLoading } = useQuery({
+    queryKey: ["skills"],
+    queryFn: async () => {
+      const response = await fetch("/api/skills");
+      if (!response.ok) throw new Error("Failed to fetch skills");
+      const data = await response.json();
+      return data.data as Skill[];
+    },
+  });
+
+  // Fetch user's skills
+  const { data: userSkills = [], isLoading: userSkillsLoading } = useQuery({
+    queryKey: ["user-skills"],
+    queryFn: async () => {
+      const response = await fetch("/api/users/me/skills");
+      if (!response.ok) throw new Error("Failed to fetch user skills");
+      const data = await response.json();
+      return data.data as UsersSkill[];
+    },
+  });
+
+  // Update user skills mutation
+  const updateSkillsMutation = useMutation({
+    mutationFn: async (skillsData: { skillId: number; learnt: boolean }[]) => {
+      const response = await fetch("/api/users/me/skills", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ skills: skillsData }),
+      });
+      if (!response.ok) throw new Error("Failed to update skills");
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user-skills"] });
+      setIsEditing(false);
+    },
+  });
+
+  // Combine skills with user status
+  const skillsWithStatus: SkillWithUserStatus[] = skills.map((skill) => {
+    const userSkill = userSkills.find(
+      (us) =>
+        (typeof us.skill === "object" ? us.skill.id : us.skill) === skill.id,
+    );
+    return {
+      ...skill,
+      userSkill,
+      isLearnt: userSkill?.learnt ?? false,
+    };
+  });
+
+  // Sort: learnt skills first
+  const sortedSkills = [...skillsWithStatus].sort((a, b) => {
+    if (a.isLearnt && !b.isLearnt) return -1;
+    if (!a.isLearnt && b.isLearnt) return 1;
+    return a.title.localeCompare(b.title);
+  });
+
+  const handleEdit = () => {
+    const initialSelected: Record<number, boolean> = {};
+    skillsWithStatus.forEach((skill) => {
+      initialSelected[skill.id] = skill.isLearnt;
+    });
+    setSelectedSkills(initialSelected);
+    setIsEditing(true);
+  };
+
+  const handleSave = () => {
+    const skillsToUpdate = Object.entries(selectedSkills).map(
+      ([skillId, learnt]) => ({
+        skillId: skillId as unknown as number,
+        learnt,
+      }),
+    );
+
+    updateSkillsMutation.mutate(skillsToUpdate);
+  };
+
+  const handleCheckboxChange = (
+    skillId: number,
+    checked: boolean | { checked: boolean },
+  ) => {
+    setSelectedSkills((prev) => ({
+      ...prev,
+      [skillId]: typeof checked === "boolean" ? checked : checked.checked,
+    }));
+  };
+
+  if (skillsLoading || userSkillsLoading) {
+    return <div className="p-6">Loading skills...</div>;
+  }
+
+  return (
+    <Container marginTop={{ base: 4, xl: 20 }} marginBottom="4">
+      <HStack
+        alignItems="baseline"
+        justifyContent="space-between"
+        marginBottom="8"
+      >
+        <panda.h1 fontSize="xl" fontWeight="medium" marginBottom="8">
+          My skills
+        </panda.h1>
+        {!isEditing ? (
+          <Button onClick={handleEdit} variant="outline">
+            <Edit className="w-4 h-4 mr-2" />
+            Edit
+          </Button>
+        ) : (
+          <Button
+            onClick={handleSave}
+            disabled={updateSkillsMutation.isPending}
+          >
+            <Save className="w-4 h-4 mr-2" />
+            {updateSkillsMutation.isPending ? "Saving..." : "Save"}
+          </Button>
+        )}
+      </HStack>
+
+      <Table.Root>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header className="w-16">Badge</Table.Header>
+            <Table.Header>Skill</Table.Header>
+            <Table.Header className="w-32 text-center">Learnt</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {sortedSkills.map((skill) => (
+            <Table.Row key={skill.id}>
+              <Table.Cell>
+                {skill.badgeImage && (
+                  <Image
+                    src={skill.badgeImage}
+                    alt={`${skill.title} badge`}
+                    className="w-8 h-8 rounded"
+                  />
+                )}
+              </Table.Cell>
+              <Table.Cell>{skill.title}</Table.Cell>
+              <Table.Cell className="text-center">
+                <Checkbox.Root
+                  checked={
+                    isEditing
+                      ? (selectedSkills[skill.id] ?? false)
+                      : skill.isLearnt
+                  }
+                  disabled={!isEditing}
+                  onCheckedChange={(checked: boolean) =>
+                    handleCheckboxChange(skill.id, checked)
+                  }
+                >
+                  <Checkbox.HiddenInput />
+                  <Checkbox.Control>
+                    <Checkbox.Indicator />
+                  </Checkbox.Control>
+                </Checkbox.Root>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+
+      {sortedSkills.length === 0 && (
+        <panda.div className="text-center py-8 text-muted-foreground">
+          No skills available
+        </panda.div>
+      )}
+    </Container>
+  );
+}

--- a/src/app/(scheduler)/api/skills/route.ts
+++ b/src/app/(scheduler)/api/skills/route.ts
@@ -1,0 +1,22 @@
+import { getPayload } from "payload";
+import config from "@/payload.config";
+
+export const GET = async () => {
+  try {
+    const payload = await getPayload({ config });
+
+    const skills = await payload.find({
+      collection: "skills",
+      sort: "title",
+    });
+
+    return Response.json({
+      success: true,
+      data: skills.docs,
+      total: skills.totalDocs,
+    });
+  } catch (error) {
+    console.error("Error fetching skills:", error);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+};

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,6 +4,7 @@ import {
   CircleUserRoundIcon,
   History,
   LogOutIcon,
+  MedalIcon,
   MenuIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -54,6 +55,14 @@ export const NavBar = async () => {
                         <HStack gap="2">
                           <CalendarDaysIcon />
                           Upcoming Shifts
+                        </HStack>
+                      </Link>
+                    </Menu.Item>
+                    <Menu.Item asChild value="skills">
+                      <Link href="/account/skills">
+                        <HStack gap="2">
+                          <MedalIcon />
+                          Skills
                         </HStack>
                       </Link>
                     </Menu.Item>

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,1 @@
+export * as Checkbox from "./styled/checkbox";

--- a/src/components/ui/recipes/checkbox.tsx
+++ b/src/components/ui/recipes/checkbox.tsx
@@ -1,0 +1,110 @@
+import { checkboxAnatomy } from "@ark-ui/react/anatomy";
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const checkbox = defineSlotRecipe({
+  slots: checkboxAnatomy.keys(),
+  className: "checkbox",
+  base: {
+    root: {
+      display: "inline-flex",
+      gap: "2",
+      alignItems: "center",
+      verticalAlign: "top",
+      position: "relative",
+      _disabled: {
+        layerStyle: "disabled",
+      },
+    },
+    control: {
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: "0",
+      borderWidth: "1px",
+      borderColor: "transparent",
+      borderRadius: "l1",
+      cursor: "pointer",
+      focusVisibleRing: "outside",
+
+      _icon: {
+        boxSize: "full",
+      },
+    },
+    label: {
+      fontWeight: "medium",
+      userSelect: "none",
+    },
+  },
+
+  variants: {
+    size: {
+      sm: {
+        root: { gap: "2" },
+        label: { textStyle: "sm" },
+        control: { boxSize: "4.5", _icon: { boxSize: "3" } },
+      },
+      md: {
+        root: { gap: "3" },
+        label: { textStyle: "md" },
+        control: { boxSize: "5", _icon: { boxSize: "3.5" } },
+      },
+      lg: {
+        root: { gap: "3" },
+        label: { textStyle: "lg" },
+        control: { boxSize: "5.5", _icon: { boxSize: "4" } },
+      },
+    },
+
+    variant: {
+      solid: {
+        control: {
+          control: {
+            borderColor: "border",
+            _checked: {
+              bg: "colorPalette.solid.bg",
+              borderColor: "colorPalette.solid.bg",
+              color: "colorPalette.solid.fg",
+            },
+            _invalid: {
+              background: "error",
+            },
+          },
+        },
+      },
+      surface: {
+        control: {
+          bg: "colorPalette.surface.bg",
+          borderWidth: "1px",
+          borderColor: "colorPalette.surface.border",
+          color: "colorPalette.surface.fg",
+        },
+      },
+      subtle: {
+        control: {
+          bg: "colorPalette.subtle.bg",
+          color: "colorPalette.subtle.fg",
+        },
+      },
+      outline: {
+        control: {
+          borderWidth: "1px",
+          borderColor: "colorPalette.outline.border",
+          color: "colorPalette.outline.fg",
+          _checked: {
+            borderColor: "colorPalette.solid.bg",
+          },
+        },
+      },
+      plain: {
+        control: {
+          color: "colorPalette.plain.fg",
+        },
+      },
+    },
+  },
+
+  defaultVariants: {
+    variant: "solid",
+    size: "md",
+  },
+});

--- a/src/components/ui/recipes/table.tsx
+++ b/src/components/ui/recipes/table.tsx
@@ -1,0 +1,113 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const table = defineSlotRecipe({
+  className: "table",
+  slots: ["root", "body", "cell", "footer", "head", "header", "row", "caption"],
+  base: {
+    root: {
+      borderCollapse: "collapse",
+      fontVariantNumeric: "lining-nums tabular-nums",
+      textAlign: "start",
+      verticalAlign: "top",
+      width: "full",
+    },
+    cell: {
+      alignItems: "center",
+      color: "fg.muted",
+      textAlign: "start",
+      textOverflow: "ellipsis",
+      textStyle: "sm",
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      boxShadow: "inset 0 -1px 0 0 var(--shadow-color)",
+      shadowColor: "border",
+      _pinned: {
+        bg: "inherit",
+        boxShadow: "inset 0 -1px 0 0 var(--shadow-color)",
+        overflow: "unset",
+        position: "sticky",
+        shadowColor: "border",
+        zIndex: 1,
+      },
+    },
+    row: {
+      _last: { "& td": { boxShadow: "none" } },
+    },
+    header: {
+      textAlign: "left",
+      verticalAlign: "middle",
+      boxShadow: "inset 0 -1px 0 0 var(--shadow-color)",
+      shadowColor: "border",
+      _pinned: {
+        position: "sticky",
+        bg: "inherit",
+        zIndex: 2,
+      },
+    },
+    head: {
+      color: "fg.muted",
+      fontWeight: "semibold",
+      textAlign: "start",
+      whiteSpace: "nowrap",
+      textStyle: "xs",
+    },
+    caption: {
+      color: "fg.subtle",
+      fontWeight: "medium",
+    },
+    footer: {
+      fontWeight: "medium",
+      "& td": {
+        boxShadow: "inset 0 1px 0 0 var(--shadow-color)!",
+        shadowColor: "border",
+      },
+    },
+  },
+  defaultVariants: {
+    size: "md",
+    variant: "plain",
+  },
+  variants: {
+    variant: {
+      surface: {
+        header: { bg: "gray.surface.bg.hover" },
+        row: { bg: "gray.surface.bg" },
+      },
+      plain: {},
+    },
+    striped: {
+      true: {
+        row: { "&:nth-of-type(odd) td": { bg: "gray.surface.bg.hover" } },
+      },
+    },
+    interactive: {
+      true: {
+        body: { "& tr": { _hover: { bg: "gray.surface.bg.hover" } } },
+      },
+    },
+    columnBorder: {
+      true: {
+        header: { "&:not(:last-of-type)": { borderInlineEndWidth: "1px" } },
+        cell: { "&:not(:last-of-type)": { borderInlineEndWidth: "1px" } },
+      },
+    },
+    stickyHeader: {
+      true: {
+        head: {
+          "& :where(tr)": {
+            top: "var(--table-sticky-offset, 0)",
+            position: "sticky",
+            zIndex: 2,
+          },
+        },
+      },
+    },
+    size: {
+      md: {
+        root: { textStyle: "sm" },
+        header: { px: "3", py: "3" },
+        cell: { px: "3", py: "3" },
+      },
+    },
+  },
+});

--- a/src/components/ui/styled/checkbox.tsx
+++ b/src/components/ui/styled/checkbox.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { Checkbox, useCheckboxContext } from "@ark-ui/react/checkbox";
+import { type ComponentProps, forwardRef } from "react";
+import { createStyleContext, panda } from "styled-system/jsx";
+import { checkbox } from "styled-system/recipes";
+import type { HTMLPandaProps } from "styled-system/types";
+
+const { withProvider, withContext } = createStyleContext(checkbox);
+
+export type RootProps = ComponentProps<typeof Root>;
+export type HiddenInputProps = ComponentProps<typeof HiddenInput>;
+
+export const Root = withProvider(Checkbox.Root, "root");
+export const RootProvider = withProvider(Checkbox.RootProvider, "root");
+export const Control = withContext(Checkbox.Control, "control");
+export const Group = withProvider(Checkbox.Group, "group");
+export const Label = withContext(Checkbox.Label, "label");
+export const HiddenInput = Checkbox.HiddenInput;
+
+export {
+  type CheckboxCheckedState as CheckedState,
+  CheckboxGroupProvider as GroupProvider,
+} from "@ark-ui/react/checkbox";
+
+export const Indicator = forwardRef<SVGSVGElement, HTMLPandaProps<"svg">>(
+  function Indicator(props, ref) {
+    const { indeterminate, checked } = useCheckboxContext();
+
+    return (
+      <Checkbox.Indicator indeterminate={indeterminate} asChild>
+        <panda.svg
+          ref={ref}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3px"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          {...props}
+        >
+          <title>Checkmark</title>
+          {indeterminate ? (
+            <path d="M5 12h14" />
+          ) : checked ? (
+            <path d="M20 6 9 17l-5-5" />
+          ) : null}
+        </panda.svg>
+      </Checkbox.Indicator>
+    );
+  },
+);

--- a/src/components/ui/styled/table.tsx
+++ b/src/components/ui/styled/table.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { ark } from "@ark-ui/react/factory";
+import type { ComponentProps } from "react";
+import { createStyleContext } from "styled-system/jsx";
+import { table } from "styled-system/recipes";
+
+const { withProvider, withContext } = createStyleContext(table);
+
+export type RootProps = ComponentProps<typeof Root>;
+export const Root = withProvider(ark.table, "root");
+export const Body = withContext(ark.tbody, "body");
+export const Caption = withContext(ark.caption, "caption");
+export const Cell = withContext(ark.td, "cell");
+export const Foot = withContext(ark.tfoot, "footer");
+export const Head = withContext(ark.thead, "head");
+export const Header = withContext(ark.th, "header");
+export const Row = withContext(ark.tr, "row");

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,1 @@
+export * as Table from "./styled/table";


### PR DESCRIPTION
This PR closes #341.

- [x] the menu item should be under “Upcoming Shifts” item (3rd in list) and open a new page
- [ ] show the skills badges on top of the page
- [x] below the badges, all skills should be listed in a table form with badge, title and a checkbox in a disabled status
- [ ] the title is clickable, when clicking, a dialog with the description is open
- [x] for the skills table: a button for Edit, it should enable the checkboxes
- [x] for the skills table: a button for Save, it calls the api and disables the checkboxes again and update skills badges
- [x] the learnt skills should be on the top of the list

## Desktop (still missing badges and description modal)
![Kapture 2026-02-01 at 23 45 27](https://github.com/user-attachments/assets/585bd2bc-9887-41e7-92a6-1703b4b296dd)
