### PR TITLE
chore: fix trivy results aggregation

### DIFF
--- a/.github/scripts/post-trivy-results.cjs
+++ b/.github/scripts/post-trivy-results.cjs
@@ -6,9 +6,9 @@ module.exports = async ({ github, context }) => {
   const trivyOutput = fs.readFileSync("./trivy-detail-table.txt", "utf8");
 
   const total = trivyOutput
-    .matchAll(/Total: (?<total>\d)/gm)
+    .matchAll(/Total: (?<total>\d+)/gm)
     .map((match) => Number(match.groups.total))
-    .reduce((acc, cur) => acc + cur);
+    .reduce((acc, cur) => acc + cur, 0);
 
   const icon = total > 0 ? ":red_circle:" : ":green_circle:";
 


### PR DESCRIPTION
* `\d` only matches a single digit, so for example 12 results would be parsed as `1`. Using `\d+` solves this by matching multiple digits.
* `reduce` fails if the input array is empty, adding 0 as the initial value solves this.