### PR TITLE
chores(deps): remove multi-ecosystem-group from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,23 +2,8 @@
 ---
 version: 2
 
-multi-ecosystem-groups:
-  bun-patch:
-    schedule:
-      interval: "weekly"
-
 updates:
   # bun itself
-  - package-ecosystem: "bun"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    patterns: [ "@types/bun" ]
-    groups:
-      bun-patch:
-        patterns: [ "@types/bun" ]
-        update-types: ["patch"]
-    multi-ecosystem-group: "bun-patch"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -28,7 +13,6 @@ updates:
       bun-patch:
         patterns: [ "oven/bun" ]
         update-types: ["patch"]
-    multi-ecosystem-group: "bun-patch"
 
   # project dependencies
 #  - package-ecosystem: "bun"


### PR DESCRIPTION
There are 3 places with bun versions that need to be updated:
1. `Dockerfile` (`oven/bun`)
2. `package.json` (`@types/bun`)
3. `.bun-version` (used by `oven-sh/setup-bun` in GitHub Actions)

Since Dependabot can only update 1 and 2 but not 3 it does not make sense to have the complexity of a `multi-ecosystem-group` in the dependabot config - we already have a script that reads the version from 1 and updates 2 and 3, plus it seems that multi-ecosystem-groups fail to be recreated with `@dependabot recreate`.