### PR TITLE
chore: print trivy results in job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,9 @@ jobs:
       - name: "Trivy: render results as table"
         run: trivy convert --scanners vuln,misconfig,secret,license --format table --table-mode detailed --output trivy-detail-table.txt trivy-result.json
 
+      - name: "Trivy: print results"
+        run: cat trivy-detail-table.txt
+
       - name: "Trivy: post results to PR"
         uses: actions/github-script@v8
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
If trivy runs for a non-PR, there is currently no way to see the findings. This change prints the findings in the pipeline.